### PR TITLE
[FIX]Actualiza el plan a IGIC si se establece a NULL en res.company

### DIFF
--- a/l10n_es_igic/__manifest__.py
+++ b/l10n_es_igic/__manifest__.py
@@ -28,7 +28,8 @@
         'data/account_account_common_igic.xml',
         'data/account_tax_group_data.xml',
         'data/taxes_common_igic.xml',
-        'data/fiscal_position_common_igic.xml'],
+        'data/fiscal_position_common_igic.xml',
+        'data/account_chart_template_data.yml'],
     'installable': True,
     'auto_install': False,
 }

--- a/l10n_es_igic/data/account_chart_template_data.yml
+++ b/l10n_es_igic/data/account_chart_template_data.yml
@@ -1,0 +1,3 @@
+-
+  !python {model: account.chart.template, id: account_chart_template_pymes_canarias}: |
+    self[0].try_loading_for_current_company()

--- a/l10n_es_igic/data/account_chart_template_igic.xml
+++ b/l10n_es_igic/data/account_chart_template_igic.xml
@@ -10,7 +10,7 @@
             <field name="cash_account_code_prefix">570</field>
             <field name="bank_account_code_prefix">572</field>
             <field name="transfer_account_id" ref="l10n_es.account_common_572999"/>
-            <field name="parent_id" ref="l10n_es.account_chart_template_common"/>
+            <field name="parent_id" ref="l10n_es.account_chart_template_pymes"/>
             <field name="property_account_receivable_id" ref="l10n_es.account_common_4300"/>
             <field name="property_account_payable_id" ref="l10n_es.account_common_4100"/>
             <field name="property_account_expense_categ_id" ref="l10n_es.account_common_600"/>


### PR DESCRIPTION
Cómo el chart del IGIC hereda de l10n_es pymes, al instalarlo no se establece por defecto ya que el campo res_company.account_chart_id no es NULL, por lo que no vemos los impuestos ni las cuentas del plan Canario.

Este fix sólo es interesante si atacamos en código la configuración, ya que con cambiar el plan en ajustes de contabilidad funciona.